### PR TITLE
Add ability to customize top bar corner radius and top bar height

### DIFF
--- a/Sources/BottomSheet/BottomSheet.swift
+++ b/Sources/BottomSheet/BottomSheet.swift
@@ -12,13 +12,13 @@ public struct BottomSheet<Content: View>: View {
     
     private var dragToDismissThreshold: CGFloat { height * 0.2 }
     private var grayBackgroundOpacity: Double { isPresented ? (0.4 - Double(draggedOffset)/600) : 0 }
-    public static var topBarHeight: CGFloat { 30 }
     
     @State private var draggedOffset: CGFloat = 0
     @State private var previousDragValue: DragGesture.Value?
 
     @Binding var isPresented: Bool
     private let height: CGFloat
+    private let topBarHeight: CGFloat
     private let topBarCornerRadius: CGFloat
     private let content: Content
     private let contentBackgroundColor: Color
@@ -28,7 +28,8 @@ public struct BottomSheet<Content: View>: View {
     public init(
         isPresented: Binding<Bool>,
         height: CGFloat,
-        topBarCornerRadius: CGFloat = topBarHeight / 3,
+        topBarHeight: CGFloat = 30,
+        topBarCornerRadius: CGFloat? = nil,
         topBarBackgroundColor: Color = Color(.systemBackground),
         contentBackgroundColor: Color = Color(.systemBackground),
         showTopIndicator: Bool,
@@ -38,7 +39,12 @@ public struct BottomSheet<Content: View>: View {
         self.contentBackgroundColor = contentBackgroundColor
         self._isPresented = isPresented
         self.height = height
-        self.topBarCornerRadius = topBarCornerRadius
+        self.topBarHeight = topBarHeight
+        if let topBarCornerRadius = topBarCornerRadius {
+            self.topBarCornerRadius = topBarCornerRadius
+        } else {
+            self.topBarCornerRadius = topBarHeight / 3
+        }
         self.showTopIndicator = showTopIndicator
         self.content = content()
     }
@@ -80,7 +86,7 @@ public struct BottomSheet<Content: View>: View {
                 .frame(width: 40, height: 6)
                 .opacity(showTopIndicator ? 1 : 0)
         }
-        .frame(width: geometry.size.width, height: BottomSheet.topBarHeight)
+        .frame(width: geometry.size.width, height: topBarHeight)
         .background(topBarBackgroundColor)
         .gesture(
             DragGesture()

--- a/Sources/BottomSheet/BottomSheet.swift
+++ b/Sources/BottomSheet/BottomSheet.swift
@@ -12,13 +12,14 @@ public struct BottomSheet<Content: View>: View {
     
     private var dragToDismissThreshold: CGFloat { height * 0.2 }
     private var grayBackgroundOpacity: Double { isPresented ? (0.4 - Double(draggedOffset)/600) : 0 }
-    private let topBarHeight: CGFloat = 30
+    public static var topBarHeight: CGFloat { 30 }
     
     @State private var draggedOffset: CGFloat = 0
     @State private var previousDragValue: DragGesture.Value?
 
     @Binding var isPresented: Bool
     private let height: CGFloat
+    private let topBarCornerRadius: CGFloat
     private let content: Content
     private let contentBackgroundColor: Color
     private let topBarBackgroundColor: Color
@@ -27,6 +28,7 @@ public struct BottomSheet<Content: View>: View {
     public init(
         isPresented: Binding<Bool>,
         height: CGFloat,
+        topBarCornerRadius: CGFloat = topBarHeight / 3,
         topBarBackgroundColor: Color = Color(.systemBackground),
         contentBackgroundColor: Color = Color(.systemBackground),
         showTopIndicator: Bool,
@@ -36,6 +38,7 @@ public struct BottomSheet<Content: View>: View {
         self.contentBackgroundColor = contentBackgroundColor
         self._isPresented = isPresented
         self.height = height
+        self.topBarCornerRadius = topBarCornerRadius
         self.showTopIndicator = showTopIndicator
         self.content = content()
     }
@@ -54,7 +57,7 @@ public struct BottomSheet<Content: View>: View {
                 }
                 .frame(height: self.height - min(self.draggedOffset*2, 0))
                 .background(self.contentBackgroundColor)
-                .cornerRadius(self.topBarHeight/3, corners: [.topLeft, .topRight])
+                .cornerRadius(self.topBarCornerRadius, corners: [.topLeft, .topRight])
                 .animation(.interactiveSpring())
                 .offset(y: self.isPresented ? (geometry.size.height/2 - self.height/2 + geometry.safeAreaInsets.bottom + self.draggedOffset) : (geometry.size.height/2 + self.height/2 + geometry.safeAreaInsets.bottom))
             }
@@ -77,7 +80,7 @@ public struct BottomSheet<Content: View>: View {
                 .frame(width: 40, height: 6)
                 .opacity(showTopIndicator ? 1 : 0)
         }
-        .frame(width: geometry.size.width, height: self.topBarHeight)
+        .frame(width: geometry.size.width, height: BottomSheet.topBarHeight)
         .background(topBarBackgroundColor)
         .gesture(
             DragGesture()

--- a/Sources/BottomSheet/ViewExtension.swift
+++ b/Sources/BottomSheet/ViewExtension.swift
@@ -12,6 +12,7 @@ public extension View {
     func bottomSheet<Content: View>(
         isPresented: Binding<Bool>,
         height: CGFloat,
+        topBarCornerRadius: CGFloat = BottomSheet<AnyView>.topBarHeight / 3,
         contentBackgroundColor: Color = Color(.systemBackground),
         topBarBackgroundColor: Color = Color(.systemBackground),
         showTopIndicator: Bool = true,
@@ -21,6 +22,7 @@ public extension View {
             self
             BottomSheet(isPresented: isPresented,
                         height: height,
+                        topBarCornerRadius: topBarCornerRadius,
                         topBarBackgroundColor: topBarBackgroundColor,
                         contentBackgroundColor: contentBackgroundColor,
                         showTopIndicator: showTopIndicator,

--- a/Sources/BottomSheet/ViewExtension.swift
+++ b/Sources/BottomSheet/ViewExtension.swift
@@ -12,7 +12,8 @@ public extension View {
     func bottomSheet<Content: View>(
         isPresented: Binding<Bool>,
         height: CGFloat,
-        topBarCornerRadius: CGFloat = BottomSheet<AnyView>.topBarHeight / 3,
+        topBarHeight: CGFloat = 30,
+        topBarCornerRadius: CGFloat? = nil,
         contentBackgroundColor: Color = Color(.systemBackground),
         topBarBackgroundColor: Color = Color(.systemBackground),
         showTopIndicator: Bool = true,
@@ -22,6 +23,7 @@ public extension View {
             self
             BottomSheet(isPresented: isPresented,
                         height: height,
+                        topBarHeight: topBarHeight,
                         topBarCornerRadius: topBarCornerRadius,
                         topBarBackgroundColor: topBarBackgroundColor,
                         contentBackgroundColor: contentBackgroundColor,

--- a/iOS Example/Sources/ContentView.swift
+++ b/iOS Example/Sources/ContentView.swift
@@ -21,7 +21,7 @@ struct ContentView: View {
             .bottomSheet(isPresented: $showList, height: 500) {
                 List(20..<40) { Text("\($0)") }
             }
-            .bottomSheet(isPresented: $showMapSetting, height: 370, showTopIndicator: false) {
+            .bottomSheet(isPresented: $showMapSetting, height: 370, topBarCornerRadius: 16, showTopIndicator: false) {
                MapSettingView()
             }
             .navigationBarTitle("Bottom Sheet")

--- a/iOS Example/Sources/ContentView.swift
+++ b/iOS Example/Sources/ContentView.swift
@@ -21,8 +21,14 @@ struct ContentView: View {
             .bottomSheet(isPresented: $showList, height: 500) {
                 List(20..<40) { Text("\($0)") }
             }
-            .bottomSheet(isPresented: $showMapSetting, height: 370, topBarCornerRadius: 16, showTopIndicator: false) {
-               MapSettingView()
+            .bottomSheet(
+                isPresented: $showMapSetting,
+                height: 370,
+                topBarHeight: 16,
+                topBarCornerRadius: 16,
+                showTopIndicator: false
+            ) {
+                MapSettingView()
             }
             .navigationBarTitle("Bottom Sheet")
             .navigationBarItems(


### PR DESCRIPTION
Now we can customize **top bar corner radius** and **top bar height** using `topBarCornerRadius` and `topBarHeight` parameter.

`topBarHeight / 3` is used as **top bar corner radius** like before unless `topBarCornerRadius` parameter is given.

`30` is used as **top bar height** like before unless `topBarHeight` parameter is given.

Screenshot: top bar corner radius to 16pt, top bar height to 16pt
![image](https://user-images.githubusercontent.com/7913887/97546776-3c654200-1a10-11eb-9f8a-3895dde63546.png)


