### PR TITLE
Change listStyle on examples to PlainListStyle

### DIFF
--- a/BottomSheet.podspec
+++ b/BottomSheet.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "BottomSheet"
-  spec.version      = "1.0.5"
+  spec.version      = "1.0.6"
   spec.summary      = "⬆️ A SwiftUI view component sliding in from bottom"
   spec.homepage     = "http://www.github.com/weitieda/bottom-sheet"
   spec.license      = { :type => "MIT", :file => "LICENSE" }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,8 @@ BottomSheet adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- 1.0.6
+
+Removing List padding on examples.
+
 ### Removed

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Same way as you use `Sheet` in `SwiftUI`
 NavigationView {
     List(0..<20) {
         Text("\($0)")
-    }
+    }.listStyle(PlainListStyle())
     .bottomSheet(isPresented: $isPresented, height: 300) {
-        List(20..<40) { Text("\($0)") }
+        List(20..<40) { Text("\($0)") }.listStyle(PlainListStyle())
     }
     .navigationBarTitle("Bottom Sheet")
     .navigationBarItems(

--- a/iOS Example/Sources/ContentView.swift
+++ b/iOS Example/Sources/ContentView.swift
@@ -17,9 +17,9 @@ struct ContentView: View {
         NavigationView {
             List(0..<20) {
                 Text("\($0)")
-            }
+            }.listStyle(PlainListStyle())
             .bottomSheet(isPresented: $showList, height: 500) {
-                List(20..<40) { Text("\($0)") }
+                List(20..<40) { Text("\($0)") }.listStyle(PlainListStyle())
             }
             .bottomSheet(
                 isPresented: $showMapSetting,


### PR DESCRIPTION
### News
Lists used on example (iOS Example) has some unespected padding (iOS 14+):

Current issue open: #5 

![image](https://user-images.githubusercontent.com/7614148/110264649-8ea70880-7f98-11eb-8d5b-48eb0e480b07.png)
![image](https://user-images.githubusercontent.com/7614148/110265156-b0ed5600-7f99-11eb-9a18-05e2149aefd7.png)

Padding was removed using:
`.listStyle(PlainListStyle())`

### After code fix:

![image](https://user-images.githubusercontent.com/7614148/110265195-cb273400-7f99-11eb-9f08-408b9ffd1faf.png)
