### PR TITLE
Feature: Configurable dismiss on overlay tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,17 @@ All notable changes to this project will be documented in this file.
 BottomSheet adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Master](https://github.com/weitieda/BottomSheet)
-### Added
 
-### Changed
+## Added
 
-- 1.0.6
+### 1.0.6
 
-Removing List padding on examples.
+- Added Posibility to configure wether the sheet dismiss when tapping outside or not.
 
-### Removed
+## Changed
+
+### 1.0.6
+
+- Removing List padding on examples.
+
+## Removed

--- a/Sources/BottomSheet/BottomSheet.swift
+++ b/Sources/BottomSheet/BottomSheet.swift
@@ -24,6 +24,7 @@ public struct BottomSheet<Content: View>: View {
     private let contentBackgroundColor: Color
     private let topBarBackgroundColor: Color
     private let showTopIndicator: Bool
+    private let dismissOnTapOutside: Bool
     
     public init(
         isPresented: Binding<Bool>,
@@ -33,6 +34,7 @@ public struct BottomSheet<Content: View>: View {
         topBarBackgroundColor: Color = Color(.systemBackground),
         contentBackgroundColor: Color = Color(.systemBackground),
         showTopIndicator: Bool,
+        dismissOnTapOutside: Bool? = nil,
         @ViewBuilder content: () -> Content
     ) {
         self.topBarBackgroundColor = topBarBackgroundColor
@@ -46,6 +48,7 @@ public struct BottomSheet<Content: View>: View {
             self.topBarCornerRadius = topBarHeight / 3
         }
         self.showTopIndicator = showTopIndicator
+        self.dismissOnTapOutside = dismissOnTapOutside ?? true
         self.content = content()
     }
     
@@ -76,7 +79,11 @@ public struct BottomSheet<Content: View>: View {
             .opacity(grayBackgroundOpacity)
             .edgesIgnoringSafeArea(.all)
             .animation(.interactiveSpring())
-            .onTapGesture { self.isPresented = false }
+            .onTapGesture {
+                if dismissOnTapOutside {
+                    self.isPresented = false
+                }
+            }
     }
     
     fileprivate func topBar(geometry: GeometryProxy) -> some View {

--- a/Sources/BottomSheet/BottomSheet.swift
+++ b/Sources/BottomSheet/BottomSheet.swift
@@ -42,11 +42,7 @@ public struct BottomSheet<Content: View>: View {
         self._isPresented = isPresented
         self.height = height
         self.topBarHeight = topBarHeight
-        if let topBarCornerRadius = topBarCornerRadius {
-            self.topBarCornerRadius = topBarCornerRadius
-        } else {
-            self.topBarCornerRadius = topBarHeight / 3
-        }
+        self.topBarCornerRadius = topBarCornerRadius ?? topBarHeight / 3
         self.showTopIndicator = showTopIndicator
         self.dismissOnTapOutside = dismissOnTapOutside ?? true
         self.content = content()

--- a/Sources/BottomSheet/ViewExtension.swift
+++ b/Sources/BottomSheet/ViewExtension.swift
@@ -17,6 +17,7 @@ public extension View {
         contentBackgroundColor: Color = Color(.systemBackground),
         topBarBackgroundColor: Color = Color(.systemBackground),
         showTopIndicator: Bool = true,
+        dismissOnTapOutside: Bool? = nil,
         @ViewBuilder content: @escaping () -> Content
     ) -> some View {
         ZStack {
@@ -28,6 +29,7 @@ public extension View {
                         topBarBackgroundColor: topBarBackgroundColor,
                         contentBackgroundColor: contentBackgroundColor,
                         showTopIndicator: showTopIndicator,
+                        dismissOnTapOutside: dismissOnTapOutside,
                         content: content)
         }
     }


### PR DESCRIPTION
After this PR, the user has the ability to choose if the sheet will be dismissed when tapped outside of it.

Made `dismissOnTapOutside` optional and with nil as default value on init, so users won't be affected by this change and will default to true if the value is absent.