### PR TITLE
Add ability to customize Bottom Sheet opening and closing animation

### DIFF
--- a/Sources/BottomSheet/BottomSheet.swift
+++ b/Sources/BottomSheet/BottomSheet.swift
@@ -41,6 +41,7 @@ public struct BottomSheet<Content: View>: View {
         self.topBarBackgroundColor = topBarBackgroundColor
         self.contentBackgroundColor = contentBackgroundColor
         self._isPresented = isPresented
+        self._gestureEnded = State(initialValue: true)
         self.height = height
         self.topBarHeight = topBarHeight
         if let topBarCornerRadius = topBarCornerRadius {
@@ -48,6 +49,7 @@ public struct BottomSheet<Content: View>: View {
         } else {
             self.topBarCornerRadius = topBarHeight / 3
         }
+        self.animation = animation
         self.showTopIndicator = showTopIndicator
         self.content = content()
     }
@@ -110,6 +112,7 @@ public struct BottomSheet<Content: View>: View {
                             return
                         }
                     }
+                    self.gestureEnded = true
                     self.previousDragValue = value
                     
                 })

--- a/Sources/BottomSheet/ViewExtension.swift
+++ b/Sources/BottomSheet/ViewExtension.swift
@@ -17,6 +17,7 @@ public extension View {
         contentBackgroundColor: Color = Color(.systemBackground),
         topBarBackgroundColor: Color = Color(.systemBackground),
         showTopIndicator: Bool = true,
+        animation: Animation = .interactiveSpring(),
         @ViewBuilder content: @escaping () -> Content
     ) -> some View {
         ZStack {
@@ -28,6 +29,7 @@ public extension View {
                         topBarBackgroundColor: topBarBackgroundColor,
                         contentBackgroundColor: contentBackgroundColor,
                         showTopIndicator: showTopIndicator,
+                        animation: animation,
                         content: content)
         }
     }

--- a/iOS Example/Sources/ContentView.swift
+++ b/iOS Example/Sources/ContentView.swift
@@ -26,7 +26,8 @@ struct ContentView: View {
                 height: 370,
                 topBarHeight: 16,
                 topBarCornerRadius: 16,
-                showTopIndicator: false
+                showTopIndicator: false,
+                animation: .spring()
             ) {
                 MapSettingView()
             }


### PR DESCRIPTION
Can now customize the animation of the  BottomSheet View opening and closing by adding the optional `animation` parameter.
When deciding not to provide the animation parameter the default animation is continued left as `.interactiveSpring()` otherwise it requires an `Animation` modifier. 

Example Video: the custom animation added to Map Settings is set to `Animation.spring(response: 0.5, dampingFraction: 2.0, blendDuration: 1.0)`

https://user-images.githubusercontent.com/36911172/115977902-0ed5fd00-a54a-11eb-99dc-48a7f33e4f93.mov

