### PR TITLE
Create bottom sheet with item binding

### DIFF
--- a/Sources/BottomSheet/ViewExtension.swift
+++ b/Sources/BottomSheet/ViewExtension.swift
@@ -50,7 +50,7 @@ public extension View {
             }
         }
         
-        return self.bottomSheet(
+        return bottomSheet(
             isPresented: isPresented,
             height: height,
             topBarHeight: topBarHeight,

--- a/Sources/BottomSheet/ViewExtension.swift
+++ b/Sources/BottomSheet/ViewExtension.swift
@@ -31,5 +31,40 @@ public extension View {
                         content: content)
         }
     }
+
+    func bottomSheet<Item: Identifiable, Content: View>(
+        item: Binding<Item?>,
+        height: CGFloat,
+        topBarHeight: CGFloat = 30,
+        topBarCornerRadius: CGFloat? = nil,
+        contentBackgroundColor: Color = Color(.systemBackground),
+        topBarBackgroundColor: Color = Color(.systemBackground),
+        showTopIndicator: Bool = true,
+        @ViewBuilder content: @escaping (Item) -> Content
+    ) -> some View {
+        let isPresented = Binding {
+            item.wrappedValue != nil
+        } set: { value in
+            if !value {
+                item.wrappedValue = nil
+            }
+        }
+        
+        return self.bottomSheet(
+            isPresented: isPresented,
+            height: height,
+            topBarHeight: topBarHeight,
+            topBarCornerRadius: topBarCornerRadius,
+            contentBackgroundColor: contentBackgroundColor,
+            topBarBackgroundColor: topBarBackgroundColor,
+            showTopIndicator: showTopIndicator
+        ) {
+            if let unwrapedItem = item.wrappedValue {
+                content(unwrapedItem)
+            } else {
+                EmptyView()
+            }
+        }
+    }
 }
 


### PR DESCRIPTION
This PR fixes https://github.com/weitieda/bottom-sheet/issues/13.

With this PR, it is now possible to show/hide the Botton sheet based on an item being nil or not.

```
@State var presentedLocation: Location?

.bottomSheet(item: $presentedLocation, height: 700) { place in
   SelectedBusinessSheet(selectedBusiness: place)
}
```

This is similar to https://developer.apple.com/documentation/swiftui/form/sheet(item:ondismiss:content:)