### PR TITLE
Fix home gesture collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ BottomSheet adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+Fix half-opened bottom sheet when returning from background.
+
 - 1.0.6
 
 Removing List padding on examples.

--- a/Sources/BottomSheet/BottomSheet.swift
+++ b/Sources/BottomSheet/BottomSheet.swift
@@ -91,7 +91,10 @@ public struct BottomSheet<Content: View>: View {
         .gesture(
             DragGesture()
                 .onChanged({ (value) in
-                    
+                    // ignore the swipe-up gesture which could collide with the iOS-global "go to homescreen"-gesture
+                    let isSwipeUp = value.startLocation.y > value.location.y
+                    if isPresented == false, isSwipeUp { return }
+
                     let offsetY = value.translation.height
                     self.draggedOffset = offsetY
                     

--- a/Sources/BottomSheet/BottomSheet.swift
+++ b/Sources/BottomSheet/BottomSheet.swift
@@ -91,9 +91,8 @@ public struct BottomSheet<Content: View>: View {
         .gesture(
             DragGesture()
                 .onChanged({ (value) in
-                    // ignore the swipe-up gesture which could collide with the iOS-global "go to homescreen"-gesture
-                    let isSwipeUp = value.startLocation.y > value.location.y
-                    if isPresented == false, isSwipeUp { return }
+                    // ignore gestures while the sheet is hidden. Otherwise it could collide with the iOS-global "go to homescreen"-gesture
+                    guard isPresented else { return }
 
                     let offsetY = value.translation.height
                     self.draggedOffset = offsetY


### PR DESCRIPTION
The home-gesture on iOS devices without a physical home button can collide with the
DragGesture that is attached to the bottom sheet. The gesture allows to hide the
presented bottom sheet by dragging the top bar down to the edge of the screen.

However, when swiping up from the bottom to send the app to the background, the
gesture still receives changes. When the bottom sheet is hidden, this can lead to a
miscalculation of the sheet position. See the attached video:

![BackgroundProblem](https://user-images.githubusercontent.com/112807/165072945-33b1dc4c-2754-401e-9f10-e20e739a562d.gif)

The fix is to ignore the swipe-up gesture when the bottom sheet is hidden.